### PR TITLE
Transmil attention scores returned

### DIFF
--- a/src/models/dsmil.py
+++ b/src/models/dsmil.py
@@ -127,7 +127,7 @@ class DSMIL(MIL):
         cls_loss = self.compute_loss(loss_fn, logits, label)
 
         results_dict = {'logits': logits, 'loss': cls_loss}
-        log_dict = {'loss': cls_loss.item() if cls_loss is not None else -1}
+        log_dict = {'loss': cls_loss.item() if cls_loss is not None else -1, "attention": intermeds['attention']}
         if not return_attention and 'attention' in log_dict:
             del log_dict['attention']
         if return_slide_feats:


### PR DESCRIPTION
## What does this request do?
Returns TransMIL attention scores properly. 

## Why is this change necessary?
The attention scores of Transmil model wasn't being returned in "forward" function.  It's the same problem in #23 . But the problem remains in the nested dictionary. 

## How was it implemented?
I just added intermeds["attention"] to log_dict. And returned a simple dictionary instead of a nested dictionary. 