### PR TITLE
Bug attention returned false

### DIFF
--- a/src/models/dsmil.py
+++ b/src/models/dsmil.py
@@ -127,12 +127,11 @@ class DSMIL(MIL):
         cls_loss = self.compute_loss(loss_fn, logits, label)
 
         results_dict = {'logits': logits, 'loss': cls_loss}
-        log_dict = {'loss': cls_loss.item() if cls_loss is not None else -1, "attention": intermeds['attention']}
-        if not return_attention and 'attention' in log_dict:
-            del log_dict['attention']
+        log_dict = {'loss': cls_loss.item() if cls_loss is not None else -1}
+        if return_attention:
+            log_dict['attention'] = intermeds['attention']
         if return_slide_feats:
             log_dict['slide_feats'] = slide_feats
-
         return results_dict, log_dict
 
 

--- a/src/models/transmil.py
+++ b/src/models/transmil.py
@@ -238,9 +238,9 @@ class TransMIL(MIL):
         logits = self.forward_head(wsi_feats)
         cls_loss = self.compute_loss(loss_fn=loss_fn, label=label, logits=logits)
         results_dict = {'logits': logits, 'loss': cls_loss}
-        log_dict = {'loss': cls_loss.item() if cls_loss is not None else -1, "attention": intermeds['attention']}
-        if not return_attention and 'attention' in log_dict:
-            del log_dict['attention']
+        log_dict = {'loss': cls_loss.item() if cls_loss is not None else -1}
+        if return_attention:
+            log_dict['attention'] = intermeds['attention']
         if return_slide_feats:
             log_dict['slide_feats'] = wsi_feats
         return results_dict, log_dict


### PR DESCRIPTION
## What does this request do?
It fixes a bug introduced in points #23 and #24  (sorry 😝). When attention scores aren't required, it crashes because it tries to access the "attention" key (which doesn't exist).

## Why is this change necessary?
Attention scores aren't returned by default. That's why it's important to fix this.

## How was it implemented?
I implemented the same process for both architectures. I simply added attention scores to the dictionary when explicitly requested.

PD: I introduced this bug to fix another one. So, it's my responsibility to fix it. Thanks for your time and patience. 